### PR TITLE
Update code_verification.py

### DIFF
--- a/taskweaver/code_interpreter/code_verification.py
+++ b/taskweaver/code_interpreter/code_verification.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple
 
 from injector import inject
 
-
 class FunctionCallValidator(ast.NodeVisitor):
     @inject
     def __init__(
@@ -17,29 +16,40 @@ class FunctionCallValidator(ast.NodeVisitor):
         self.errors = []
         self.allowed_modules = allowed_modules
         self.blocked_functions = blocked_functions
+        self.alias_map = {}  # Ajout pour suivre les alias
+
+    def visit_Assign(self, node):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                if isinstance(node.value, ast.Name):
+                    # Capture des alias si la valeur assignée est une fonction bloquée
+                    if node.value.id in self.blocked_functions:
+                        self.alias_map[target.id] = node.value.id
 
     def visit_Call(self, node):
         if len(self.blocked_functions) > 0:
             if isinstance(node.func, ast.Name):
                 function_name = node.func.id
-                if function_name in self.blocked_functions:
+               # Vérification de la fonction elle-même ou de son alias
+                if function_name in self.blocked_functions or function_name in self.alias_map:
                     self.errors.append(
                         f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
-                        f"=> Function '{node.func.id}' is not allowed.",
+                        "=> Function '{function_name}' or its alias is not allowed.",
                     )
-                    return False
+                    return False  # Arrêt de l'exécution si une fonction bloquée ou son alias est utilisé 
                 return True
             elif isinstance(node.func, ast.Attribute):
                 function_name = node.func.attr
-                if function_name in self.blocked_functions:
+                if function_name in self.blocked_functions or function_name in self.alias_map:
                     self.errors.append(
                         f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
-                        f"=> Function '{function_name}' is not allowed.",
+                        f"=> Function '{function_name}' or its alias is not allowed.",
                     )
                     return False
                 return True
             else:
                 return True
+
     def visit_Import(self, node):
         for alias in node.names:
             if "." in alias.name:
@@ -56,6 +66,7 @@ class FunctionCallValidator(ast.NodeVisitor):
                     f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
                     f"=> Importing module '{module_name}' is not allowed. ",
                 )
+
     def visit_ImportFrom(self, node):
         if "." in node.module:
             module_name = node.module.split(".")[0]
@@ -71,8 +82,11 @@ class FunctionCallValidator(ast.NodeVisitor):
                 f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
                 f"=>  Importing from module '{node.module}' is not allowed.",
             )
+
     def generic_visit(self, node):
         super().generic_visit(node)
+
+
 def format_code_correction_message() -> str:
     return (
         "The generated code has been verified and some errors are found. "
@@ -80,18 +94,24 @@ def format_code_correction_message() -> str:
         "please do it and try again.\n"
         "Otherwise, please explain the problem to me."
     )
+
+
 def separate_magics_and_code(input_code: str) -> Tuple[List[str], str, List[str]]:
     line_magic_pattern = re.compile(r"^\s*%\s*[a-zA-Z_]\w*")
     cell_magic_pattern = re.compile(r"^\s*%%\s*[a-zA-Z_]\w*")
     shell_command_pattern = re.compile(r"^\s*!")
+
     magics = []
     python_code = []
     package_install_commands = []
+
     lines = input_code.splitlines()
     inside_cell_magic = False
+
     for line in lines:
         if not line.strip() or line.strip().startswith("#"):
             continue
+
         if inside_cell_magic:
             magics.append(line)
             if not line.strip():
@@ -110,6 +130,8 @@ def separate_magics_and_code(input_code: str) -> Tuple[List[str], str, List[str]
             python_code.append(line)
     python_code_str = "\n".join(python_code)
     return magics, python_code_str, package_install_commands
+
+
 def code_snippet_verification(
     code_snippet: str,
     code_verification_on: bool = False,
@@ -124,6 +146,7 @@ def code_snippet_verification(
         if len(magics) > 0:
             errors.append(f"Magic commands except package install are not allowed. Details: {magics}")
         tree = ast.parse(python_code)
+
         processed_lines = []
         for line in python_code.splitlines():
             if not line.strip() or line.strip().startswith("#"):

--- a/taskweaver/code_interpreter/code_verification.py
+++ b/taskweaver/code_interpreter/code_verification.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Tuple
 
 from injector import inject
 
-
 class FunctionCallValidator(ast.NodeVisitor):
     @inject
     def __init__(
@@ -17,24 +16,34 @@ class FunctionCallValidator(ast.NodeVisitor):
         self.errors = []
         self.allowed_modules = allowed_modules
         self.blocked_functions = blocked_functions
+        self.alias_map = {}  # Ajout pour suivre les alias
+
+    def visit_Assign(self, node):
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                if isinstance(node.value, ast.Name):
+                    # Capture des alias si la valeur assignée est une fonction bloquée
+                    if node.value.id in self.blocked_functions:
+                        self.alias_map[target.id] = node.value.id
 
     def visit_Call(self, node):
         if len(self.blocked_functions) > 0:
             if isinstance(node.func, ast.Name):
                 function_name = node.func.id
-                if function_name in self.blocked_functions:
+               # Vérification de la fonction elle-même ou de son alias
+                if function_name in self.blocked_functions or function_name in self.alias_map:
                     self.errors.append(
                         f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
-                        f"=> Function '{node.func.id}' is not allowed.",
+                        "=> Function '{function_name}' or its alias is not allowed.",
                     )
-                    return False
+                    return False  # Arrêt de l'exécution si une fonction bloquée ou son alias est utilisé 
                 return True
             elif isinstance(node.func, ast.Attribute):
                 function_name = node.func.attr
-                if function_name in self.blocked_functions:
+                if function_name in self.blocked_functions or function_name in self.alias_map:
                     self.errors.append(
                         f"Error on line {node.lineno}: {self.lines[node.lineno - 1]} "
-                        f"=> Function '{function_name}' is not allowed.",
+                        f"=> Function '{function_name}' or its alias is not allowed.",
                     )
                     return False
                 return True
@@ -150,3 +159,4 @@ def code_snippet_verification(
     except SyntaxError as e:
         # print(f"Syntax error: {e}")
         return [f"Syntax error: {e}"]
+

--- a/taskweaver/code_interpreter/code_verification.py
+++ b/taskweaver/code_interpreter/code_verification.py
@@ -25,6 +25,7 @@ class FunctionCallValidator(ast.NodeVisitor):
                     # Capture des alias si la valeur assignée est une fonction bloquée
                     if node.value.id in self.blocked_functions:
                         self.alias_map[target.id] = node.value.id
+                        self.blocked_functions.append(target.id)
 
     def visit_Call(self, node):
         if len(self.blocked_functions) > 0:

--- a/tests/unit_tests/test_code_verification.py
+++ b/tests/unit_tests/test_code_verification.py
@@ -43,6 +43,27 @@ def test_block_function():
     print("---->", code_verify_errors)
     assert len(code_verify_errors) == 2
 
+def test_block_functions_aliases_bypass():
+    allowed_modules = []
+    blocked_functions = ["exec", "eval"]
+    code_snippet = (
+        "alias_exec = exec\n"
+        "alias_exec('import os')\n"
+        "alias_exec_second = alias_exec\n"
+        "alias_exec_second('import os')\n"
+        "alias_eval = eval\n"
+        "alias_eval('import sys')\n"
+        "alias_eval_second = alias_eval\n"
+        "alias_eval_second('import sys')\n"
+    )
+    code_verify_errors = code_snippet_verification(
+        code_snippet,
+        allowed_modules=allowed_modules,
+        code_verification_on=True,
+        blocked_functions=blocked_functions,
+    )
+    print("---->", code_verify_errors)
+    assert len(code_verify_errors) == 4
 
 def test_normal_code():
     allowed_modules = []


### PR DESCRIPTION
The update to `code_verification.py` a  key addition is the `alias_map` dictionary within the `FunctionCallValidator` class's `__init__` method, designed to record mappings between aliases and the original names of blocked functions. This feature plays a vital role in identifying indirect usage of restricted functions.

The introduction of the `visit_Assign` method marks a significant step forward in scrutinizing assignments within the code's abstract syntax tree (AST). This method carefully examines assignment statements to detect when a variable is assigned the value of a function that's listed among the blocked functions, effectively creating an alias. Such detections are logged in `alias_map`, enhancing the system's ability to recognize attempts to indirectly invoke blocked functions.

Further modifications to the `visit_Call` method expand its capacity to not only check for direct references to blocked functions in function calls but also to identify calls involving aliases for blocked functions, as noted in `alias_map`. This ensures comprehensive detection of both direct and indirect attempts to use restricted functions. If any violations are identified—whether through direct calls or aliases—an error message is appended to the list of validation errors, flagging a validation failure. If no such issues are found, the code segment passes validation, affirming its adherence to security protocols.